### PR TITLE
fix: use GitHub App token for bypass permissions on push

### DIFF
--- a/.github/workflows/update-formulas.yml
+++ b/.github/workflows/update-formulas.yml
@@ -11,10 +11,17 @@ jobs:
   update-formula:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate GitHub App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.GH_APP_CLIENT_ID }}
+          private-key: ${{ secrets.GH_APP_PEM }}
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: Update formula
         run: |


### PR DESCRIPTION
Fixes the branch protection rule violation when updating formulas.

The workflow now uses the GitHub App token (which has bypass permissions) instead of the default GITHUB_TOKEN for checkout and push operations. This allows the automated formula updates to bypass the branch protection rules that require pull requests.