### PR TITLE
Add graphify-go formula

### DIFF
--- a/Formula/graphify-go.rb
+++ b/Formula/graphify-go.rb
@@ -1,0 +1,36 @@
+class GraphifyGo < Formula
+  desc "Turn a codebase into a queryable knowledge graph (Go/JS/TS)"
+  homepage "https://github.com/dobbo-ca/graphify-go"
+  version "v0.0.0"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/dobbo-ca/graphify-go/releases/download/v0.0.0/graphify-go-v0.0.0-darwin-arm64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/dobbo-ca/graphify-go/releases/download/v0.0.0/graphify-go-v0.0.0-darwin-amd64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/dobbo-ca/graphify-go/releases/download/v0.0.0/graphify-go-v0.0.0-linux-arm64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/dobbo-ca/graphify-go/releases/download/v0.0.0/graphify-go-v0.0.0-linux-amd64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  def install
+    bin.install "graphify"
+  end
+
+  test do
+    system "#{bin}/graphify", "version"
+  end
+end


### PR DESCRIPTION
Template formula for [dobbo-ca/graphify-go](https://github.com/dobbo-ca/graphify-go). Version + SHA256s are placeholders; the existing update-formula repository_dispatch handler fills them on the first graphify-go release (payload formula: graphify-go). Installed binary is graphify — brew install dobbo-ca/taps/graphify-go after the first release.