### PR TITLE
feat: add graphify-go formula

### DIFF
--- a/Formula/graphify-go.rb
+++ b/Formula/graphify-go.rb
@@ -1,0 +1,39 @@
+class GraphifyGo < Formula
+  desc "Turn a codebase into a queryable knowledge graph (Go/JS/TS)"
+  homepage "https://github.com/dobbo-ca/graphify-go"
+  version "v0.0.0"
+  license "MIT"
+
+  # Conflict with official graphify
+  conflicts_with "graphify", because: "both install 'graphify' binary"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/dobbo-ca/graphify-go/releases/download/v0.0.0/graphify-go-v0.0.0-darwin-arm64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/dobbo-ca/graphify-go/releases/download/v0.0.0/graphify-go-v0.0.0-darwin-amd64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/dobbo-ca/graphify-go/releases/download/v0.0.0/graphify-go-v0.0.0-linux-arm64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/dobbo-ca/graphify-go/releases/download/v0.0.0/graphify-go-v0.0.0-linux-amd64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  def install
+    bin.install "graphify"
+  end
+
+  test do
+    system "#{bin}/graphify", "--version"
+  end
+end

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Azure CLI alternative written in Go.
 brew install az-go
 ```
 
+### graphify-go
+
+Turn a codebase into a queryable knowledge graph (Go/JS/TS).
+
+```bash
+brew install graphify-go
+```
+
 ## Conflict Resolution
 
 The `az-go` formula conflicts with the official `azure-cli` package. If you have `azure-cli` installed, you must uninstall it first:
@@ -25,5 +33,12 @@ The `az-go` formula conflicts with the official `azure-cli` package. If you have
 ```bash
 brew uninstall azure-cli
 brew install az-go
+```
+
+The `graphify-go` formula installs a `graphify` binary and conflicts with the official `graphify` package. If you have `graphify` installed, you must uninstall it first:
+
+```bash
+brew uninstall graphify
+brew install graphify-go
 ```
 


### PR DESCRIPTION
Adds placeholder `graphify-go` Homebrew formula (installs `graphify` binary, conflicts with official `graphify`).

First release of dobbo-ca/graphify-go will auto-fill version + SHA256s via the existing `update-formula` repository_dispatch flow (handler errors if the file is absent, so the placeholder must land first — same pattern as az-go/jt).

- Asset naming matches release.yml: `graphify-go-${VERSION}-{os}-{arch}.tar.gz`
- Binary inside tarball: `graphify`
- README updated with install + conflict-resolution notes