### PR TITLE
feat: add graphify conflict detection to graphify-go

### DIFF
--- a/Formula/graphify-go.rb
+++ b/Formula/graphify-go.rb
@@ -4,6 +4,9 @@ class GraphifyGo < Formula
   version "v0.0.0"
   license "MIT"
 
+  # Conflict with official graphify
+  conflicts_with "graphify", because: "both install 'graphify' binary"
+
   on_macos do
     if Hardware::CPU.arm?
       url "https://github.com/dobbo-ca/graphify-go/releases/download/v0.0.0/graphify-go-v0.0.0-darwin-arm64.tar.gz"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ Azure CLI alternative written in Go.
 brew install az-go
 ```
 
+### graphify-go
+
+Turn a codebase into a queryable knowledge graph (Go/JS/TS).
+
+```bash
+brew install graphify-go
+```
+
 ## Conflict Resolution
 
 The `az-go` formula conflicts with the official `azure-cli` package. If you have `azure-cli` installed, you must uninstall it first:
@@ -25,5 +33,12 @@ The `az-go` formula conflicts with the official `azure-cli` package. If you have
 ```bash
 brew uninstall azure-cli
 brew install az-go
+```
+
+The `graphify-go` formula installs a `graphify` binary and conflicts with the official `graphify` package. If you have `graphify` installed, you must uninstall it first:
+
+```bash
+brew uninstall graphify
+brew install graphify-go
 ```
 


### PR DESCRIPTION
Follow-up to #2. The merged graphify-go formula installs a `graphify` binary but had no conflict guard against the official `graphify` package.

- Add `conflicts_with "graphify"` (mirrors az-go ↔ azure-cli pattern)
- Add README install + conflict-resolution section for graphify-go

Leaves version/SHA placeholder logic untouched — first release auto-fills via the `update-formula` dispatch.