### PR TITLE
feat: add autoresearch formula (karp)

### DIFF
--- a/Formula/autoresearch.rb
+++ b/Formula/autoresearch.rb
@@ -1,0 +1,22 @@
+class Autoresearch < Formula
+  desc "Overnight optimization agent (Karpathy auto-research loop) on a local LLM"
+  homepage "https://github.com/dobbo-ca/autoresearch"
+  version "v0.0.0"
+
+  # macOS Apple Silicon only — the managed runtime (llama-server on Metal)
+  # supports darwin/arm64 today. Add stanzas as more platforms are released.
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/dobbo-ca/autoresearch/releases/download/v0.0.0/autoresearch-v0.0.0-darwin-arm64.tar.gz"
+      sha256 "0000000000000000000000000000000000000000000000000000000000000000"
+    end
+  end
+
+  def install
+    bin.install "karp"
+  end
+
+  test do
+    system "#{bin}/karp", "version"
+  end
+end


### PR DESCRIPTION
Adds `Formula/autoresearch.rb` so `brew install dobbo-ca/taps/autoresearch` installs the `karp` CLI.

- Placeholder `version "v0.0.0"` + zeroed sha — the `autoresearch` repo's release workflow fills these in via the existing `update-formula` `repository_dispatch` (handled by `update-formulas.yml`, no change needed here).
- **darwin/arm64 only** — the managed runtime (llama-server on Metal) supports macOS Apple Silicon today; structured so more platforms are additive.
- Installs the binary as **`karp`** (the CLI was renamed from `ar` to avoid shadowing the system `/usr/bin/ar` archiver).

**Merge this before the autoresearch release PR** — the tap's `update-formulas.yml` errors if the formula file is absent when the first release dispatches.