### PR TITLE
Add editorlint formula (CI-driven template seed)

### DIFF
--- a/Formula/editorlint.rb
+++ b/Formula/editorlint.rb
@@ -1,0 +1,58 @@
+class Editorlint < Formula
+  desc "A comprehensive tool to validate and fix files according to .editorconfig specifications"
+  homepage "https://github.com/dobbo-ca/editorlint"
+  version "0.3.0"
+  license "MIT"
+
+  on_macos do
+    if Hardware::CPU.arm?
+      url "https://github.com/dobbo-ca/editorlint/releases/download/0.3.0/editorlint-0.3.0-darwin-arm64.tar.gz"
+      sha256 "a49bfbcbeeeca6be9151bd7e53f6ec4cf4c3cdd0f80759458a11557cd5fc8cd7"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/dobbo-ca/editorlint/releases/download/0.3.0/editorlint-0.3.0-darwin-amd64.tar.gz"
+      sha256 "8f5cc1563e2710ab6ac8d1e7f88f9ac5189fb78480fd56b8a404dbdf8756344f"
+    end
+  end
+
+  on_linux do
+    if Hardware::CPU.arm?
+      url "https://github.com/dobbo-ca/editorlint/releases/download/0.3.0/editorlint-0.3.0-linux-arm64.tar.gz"
+      sha256 "311c191ed04e3da19eb4558413c43fd8f0968a9446c2377550f3508e40e79faf"
+    end
+    if Hardware::CPU.intel?
+      url "https://github.com/dobbo-ca/editorlint/releases/download/0.3.0/editorlint-0.3.0-linux-amd64.tar.gz"
+      sha256 "70736267981aca8efd187a27d26e68ed7785d7d42d2331ac0d3bb5b207835dca"
+    end
+  end
+
+  def install
+    bin.install "editorlint"
+  end
+
+  test do
+    # Create a test .editorconfig file
+    (testpath/".editorconfig").write <<~EOS
+      root = true
+
+      [*]
+      insert_final_newline = true
+      trim_trailing_whitespace = true
+    EOS
+
+    # Create a test file with violations
+    (testpath/"test.txt").write "test with trailing spaces   "
+
+    # Run editorlint and expect it to find violations
+    output = shell_output("#{bin}/editorlint test.txt", 1)
+    assert_match "validation failed", output
+    assert_match "trim_trailing_whitespace", output
+
+    # Test the fix functionality
+    system bin/"editorlint", "--fix", "test.txt"
+
+    # Verify the file was fixed
+    fixed_content = File.read(testpath/"test.txt")
+    assert_equal "test with trailing spaces\n", fixed_content
+  end
+end


### PR DESCRIPTION
## What

Seeds `Formula/editorlint.rb` in the tap so the `update-formula` `repository_dispatch` receiver (`update-formulas.yml`) has a target when `dobbo-ca/editorlint` starts publishing releases.

Part of the **editorlint consolidation** migration (phase 1 — prep dobbo-ca targets). Tracking: dobbo-ca/.github#2.

## Details

- Adapted from the `graphify-go.rb` template so it matches this tap's generic receiver structure.
- URLs point at `dobbo-ca/editorlint` with **hyphenated** asset names — `editorlint-<version>-<os>-<arch>.tar.gz` — to match the receiver's sed patterns and the locked D4 asset-naming decision.
- Keeps editorlint's `desc` + rich `test do` block (validate → `--fix` → assert fixed).
- **SHA256s are placeholders** carried over from the last `0.3.0` build. The formula is not installable until the first hyphenated release publishes; the first real dispatch overwrites `version`, URLs, and all four SHAs.

## Verification

Receiver (`update-formulas.yml`) sed compatibility confirmed:
- `version "0.3.0"` ← `s|version ".*"|...|`
- `editorlint-0.3.0-darwin-arm64.tar.gz` ← `${FORMULA}-v\?[0-9.]*-darwin-arm64.tar.gz`
- `/download/0.3.0/` ← `/download/v\?[0-9.]*[0-9]/`
- per-platform `sha256` ← `/…-<os>-<arch>.tar.gz/,/sha256/` range seds

No behavior change to any existing formula.